### PR TITLE
Misc build improvements

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -32,7 +32,7 @@ my %WriteMakefileArgs = (
 		'strict' => 0,
 		'warnings' => 0,
 	},
-	'SIGN' => 1,
+	( ! exists $ENV{CI} ? ( 'SIGN' => 1 ) : () ),
 	'TEST_REQUIRES' => {
 		'Test::Alien' => 0,
 		'Test::Alien::Diag' => 0,

--- a/alienfile
+++ b/alienfile
@@ -3,7 +3,7 @@ use alienfile;
 plugin 'PkgConfig' => 'ddjvuapi';
 
 share {
-	requires 'ExtUtils::CppGuess';
+	requires 'ExtUtils::CppGuess' => '0.13';
 	plugin 'Decode::SourceForge';
 	start_url 'https://sourceforge.net/projects/djvu/files/DjVuLibre/3.5.28/';
 	plugin 'Download' => (


### PR DESCRIPTION
- Skip signing in CI environment
- Require `ExtUtils::CppGuess` 0.13 for `linker_flags`
